### PR TITLE
Refactor notification flag and notification ordering

### DIFF
--- a/src/components/notifications/Notifications.js
+++ b/src/components/notifications/Notifications.js
@@ -51,7 +51,7 @@ const Notifications = () => {
     return () => {
       socket.off('new notification')
     }
-  }, [dispatch, token, userGroups, userId])
+  }, [dispatch, socket, token, userGroups, userId])
 
   // Retrieve email and location as those are required by JOI check on backend
   const { email, location } = useSelector(

--- a/src/components/notifications/Notifications.js
+++ b/src/components/notifications/Notifications.js
@@ -95,7 +95,15 @@ const Notifications = () => {
 
   return (
     <Container>
-      {notifications.map(activity => (
+      {notifications.sort((e1, e2) => {
+        if (e1.created_at > e2.created_at) {
+          return 1;
+        } else if (e1.created_at < e2.created_at) {
+          return -1;
+        } else {
+          return 0;
+        }
+      }).map(activity => (
         <NotificationsCard activity={activity} key={activity.id} />
       ))}
     </Container>


### PR DESCRIPTION
# Description

Made changes to the notification flag so that it reads from the redux store of notifications instead of from the entire feed.

Also fixed the ordering of notifications so that they're ordered by earliest timestamp to oldest.

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
