### PR TITLE
fixed blockedview component overlap on landscape mobile orientation

### DIFF
--- a/src/components/posts/BlockedView.js
+++ b/src/components/posts/BlockedView.js
@@ -5,7 +5,6 @@ import LockIcon from '@material-ui/icons/Lock'
 import { withRouter } from 'react-router-dom'
 
 const BlockedView = () => {
-
   return (
     <BlockedContainer>
       <Content>
@@ -20,10 +19,8 @@ const BlockedContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-  background: url(${replies}) !important;
   background-size: cover;
   overflow: hidden;
-  position: absolute;
   height: 47vh;
   bottom: 169px;
 `
@@ -32,7 +29,6 @@ const Content = styled.div`
   padding-top: 5vh;
   width: 80%;
   position: relative;
-  z-index: 1;
 `
 
 export default withRouter(BlockedView)


### PR DESCRIPTION
# Description
blockedview component would overlap with the group info component with a mobile landscape view, adjusted css positioning to fix it
Describe change or new feature here.

## Change status

- [x] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
